### PR TITLE
Update docfx.json for docfxv3 migration

### DIFF
--- a/dynamics-nav-app/docfx.json
+++ b/dynamics-nav-app/docfx.json
@@ -8,7 +8,6 @@
         ],
         "exclude": [
           "**/obj/**",
-          "../**",
           "**/includes/**",
           "**/_themes/**",
           "**/_themes.pdf/**",
@@ -28,7 +27,6 @@
         ],
         "exclude": [
           "**/obj/**",
-          "../**",
           "**/includes/**"
         ]
       }


### PR DESCRIPTION
'../**' would exclude everything in the repository in v3, and remove them is safe for v2.